### PR TITLE
SD-265 Default implementation for listener callbacks virtual destructor

### DIFF
--- a/lib/c++/src/cave_talk.cc
+++ b/lib/c++/src/cave_talk.cc
@@ -20,6 +20,8 @@
 namespace cave_talk
 {
 
+ListenerCallbacks::~ListenerCallbacks() = default;
+
 Listener::Listener(CaveTalk_Error_t (*receive)(void *const data, const size_t size, size_t *const bytes_received),
                    std::shared_ptr<ListenerCallbacks> listener_callbacks) : listener_callbacks_(listener_callbacks)
 {

--- a/tests/c++/cave_talk_tests.cc
+++ b/tests/c++/cave_talk_tests.cc
@@ -18,8 +18,6 @@
 static const std::size_t kMaxMessageLength = 255U;
 static RingBuffer<uint8_t, kMaxMessageLength> ring_buffer;
 
-cave_talk::ListenerCallbacks::~ListenerCallbacks() = default;
-
 class MockListenerCallbacks : public cave_talk::ListenerCallbacks
 {
     public:

--- a/tests/c/cave_talk_tests.cc
+++ b/tests/c/cave_talk_tests.cc
@@ -150,9 +150,6 @@ const CaveTalk_ListenCallbacks_t kCaveTalk_ListenCallbacksInterface = {
     .hear_config_encoders = HearConfigEncoder,
 };
 
-
-ListenCallbacksInterface::~ListenCallbacksInterface() = default;
-
 class MockListenerCallbacks : public ListenCallbacksInterface
 {
     public:


### PR DESCRIPTION
A default implementation of the virtual destructor is needed to use the listener callbacks, so provide one with the rest of the implementation.