### PR TITLE
SD-281 arming message

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ CAVEMAN controller message protocol
 1. Version refers to the communication version that packet adheres to, starting from V1 represented as 0x01
 2. ID refers to the specific message being sent by the packet. Here is a list of the currently supported messages.
 
-| ID   | Name            | Descriptor                                                             |
-| ---- | --------------- | ---------------------------------------------------------------------- |
-| 0x01 | Ooga            | CAVeTalk Ping Message, should receive "Booga" back from the controller |
-| 0x02 | Movement        | Describes the Speed [m/s] & Turn Rate of the Rover [rad/s]             |
-| 0x03 | Camera Movement | Describes the Camera Pan [radians] and Tilt Servo Angles [radians]     |
-| 0x04 | Lights          | Toggles the Onboard Headlights                                         |
-| 0x05 | Mode            | Switches between Manual Driving Mode and Autonomous Driving Mode       |
-| 0x06 | Odometry        | Describes the 3 relative acceleration axes [m/s^2], 3 gyroscopic axes [rad/s], and 4 encoder values for each wheel [rad/s] |
-| 0x07 | Logging         | Send String Messages Between Devices |
-| 0x08 | Configuration - Servos - Wheels  | Send Wheel Servo Configuration Parameters Between Devices |
-| 0x09 | Configuration - Servos - Cams  | Send Camera Servo Configuration Parameters Between Devices |
-| 0x0A | Configuration - Motors  | Send Motor Configuration Parameters Between Devices |
-| 0x0B | Configuration - Encoders   | Send Encoder Configuration Parameters Between Devices |
+| ID   | Name                            | Descriptor                                                                                                                 |
+| ---- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 0x01 | Ooga                            | CAVeTalk Ping Message, should receive "Booga" back from the controller                                                     |
+| 0x02 | Movement                        | Describes the Speed [m/s] & Turn Rate of the Rover [rad/s]                                                                 |
+| 0x03 | Camera Movement                 | Describes the Camera Pan [radians] and Tilt Servo Angles [radians]                                                         |
+| 0x04 | Lights                          | Toggles the Onboard Headlights                                                                                             |
+| 0x05 | Arm                             | Enable or disable driving and steering                                                                                     |
+| 0x06 | Odometry                        | Describes the 3 relative acceleration axes [m/s^2], 3 gyroscopic axes [rad/s], and 4 encoder values for each wheel [rad/s] |
+| 0x07 | Logging                         | Send String Messages Between Devices                                                                                       |
+| 0x08 | Configuration - Servos - Wheels | Send Wheel Servo Configuration Parameters Between Devices                                                                  |
+| 0x09 | Configuration - Servos - Cams   | Send Camera Servo Configuration Parameters Between Devices                                                                 |
+| 0x0A | Configuration - Motors          | Send Motor Configuration Parameters Between Devices                                                                        |
+| 0x0B | Configuration - Encoders        | Send Encoder Configuration Parameters Between Devices                                                                      |
 
 3. Length refers to the length of the packet in bytes
 4. Payload refers to the main piece of information sent in the packet
@@ -37,19 +37,19 @@ CAVEMAN controller message protocol
 When building the C version of this library and/or using this library on an embedded system, follow these steps to setup Protobufs:
 
 1. Initialize and update submodules
-
+   
    `git submodule update --init --recursive `
-
+   
    - Use this command to see the progress of each submodule pull
-
+     
       `git submodule update --init --recursive --progress`
 
 2. Make the script to generate the Protobuf payloads for C with `nanopb` executable.
-
+   
    `chmod +x tools/nanopb/generate.sh`
 
 3. Run the `generate` script to generate the Protobuf payloads for C with `nanopb`.  This step requires Python3 to be installed.
-
+   
     `./tools/nanopb/generate.sh`
 
 ### C++
@@ -57,60 +57,65 @@ When building the C version of this library and/or using this library on an embe
 When building the C++ version of this library, follow these steps to setup Protobufs:
 
 1. Initialize and update submodules
-
+   
    `git submodule update --init --recursive`
-
+   
    - Use this command to see the progress of each submodule pull
-
+     
       `git submodule update --init --recursive --progress`
 
 2. Navigate to the `protobuf` directory
-
+   
    `cd external/protobuf`
 
 3. Configure CMake build
-
+   
    `cmake -S . -B _build -DCMAKE_INSTALL_PREFIX=_build/protobuf-install -DCMAKE_CXX_STANDARD=20 -G Ninja -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF -DABSL_PROPAGATE_CXX_STD=ON`
 
 4. Build `protobufs`
-
+   
    `cmake --build _build --config Release`
 
 5. Install `protobufs` in `external/protobufs/_build/protobuf-install`
-
+   
    `cmake --build _build -t install`
 
 ## Build
 
 Prerequisites
-- CMake >= 3.30
-- Ninja
-- C compiler that supports at least C11
-- C++ compiler that supports at least C++20
-- Python3 >= 3.9 with python3-venv installed
-- Gcovr (optional)
 
+- CMake >= 3.30
+
+- Ninja
+
+- C compiler that supports at least C11
+
+- C++ compiler that supports at least C++20
+
+- Python3 >= 3.9 with python3-venv installed
+
+- Gcovr (optional)
 1. Setup Protobufs for the version(s) of the library being built.  See [Protobufs](#protobufs).
 
 2. See the `docs` directory for how to perform static analysis and code formatting. **You must set up Cppcheck and Uncrustify before configuring CMake.**
 
 3. Configure CMake.
-
+   
    `cmake -B build -G Ninja` or `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCAVETALK_BUILD_TESTS=ON` to build with tests
 
 4. Run the static analysis and code formatting tools.
-
+   
    - Cppcheck: `cmake --build build -t cppcheck`
    - Uncrustify: `cmake --build build -t uncrustify`
 
 5. Build the project.
-
+   
    `cmake --build build`
 
 6. If the project was configured to build tests, run the tests.
-
+   
    `cmake --build build -t test`
 
 7. If the project was configured to build tests and Gcovr is installed, generate a coverage report.  The coverage report can be found in the `build` directory at `coverage.html`. 
-
+   
    `cmake --build build -t coverage-no-test` or `cmake --build build -t coverage` to run the tests and generate the coverage report in a single command

--- a/lib/c++/inc/cave_talk.h
+++ b/lib/c++/inc/cave_talk.h
@@ -27,7 +27,7 @@ class ListenerCallbacks
         virtual void HearMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate)                                                                         = 0;
         virtual void HearCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt)                                                                                             = 0;
         virtual void HearLights(const bool headlights)                                                                                                                                         = 0;
-        virtual void HearMode(const bool manual)                                                                                                                                               = 0;
+        virtual void HearArm(const bool arm)                                                                                                                                                   = 0;
         virtual void HearOdometry(const Imu &IMU, const Encoder &encoder_wheel_0, const Encoder &encoder_wheel_1, const Encoder &encoder_wheel_2, const Encoder &encoder_wheel_3)              = 0;
         virtual void HearLog(const char *const log)                                                                                                                                            = 0;
         virtual void HearConfigServoWheels(const Servo &servo_wheel_0, const Servo &servo_wheel_1, const Servo &servo_wheel_2, const Servo &servo_wheel_3)                                     = 0;
@@ -52,7 +52,7 @@ class Listener
         CaveTalk_Error_t HandleMovement(const CaveTalk_Length_t length) const;
         CaveTalk_Error_t HandleCameraMovement(const CaveTalk_Length_t length) const;
         CaveTalk_Error_t HandleLights(const CaveTalk_Length_t length) const;
-        CaveTalk_Error_t HandleMode(const CaveTalk_Length_t length) const;
+        CaveTalk_Error_t HandleArm(const CaveTalk_Length_t length) const;
         CaveTalk_Error_t HandleOdometry(const CaveTalk_Length_t length) const;
         CaveTalk_Error_t HandleLog(const CaveTalk_Length_t length) const;
         CaveTalk_Error_t HandleConfigServoWheels(const CaveTalk_Length_t length) const;
@@ -76,7 +76,7 @@ class Talker
         CaveTalk_Error_t SpeakMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate);
         CaveTalk_Error_t SpeakCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt);
         CaveTalk_Error_t SpeakLights(const bool headlights);
-        CaveTalk_Error_t SpeakMode(const bool manual);
+        CaveTalk_Error_t SpeakArm(const bool arm);
         CaveTalk_Error_t SpeakOdometry(const Imu &IMU, const Encoder &encoder_wheel_0, const Encoder &encoder_wheel_1, const Encoder &encoder_wheel_2, const Encoder &encoder_wheel_3);
         CaveTalk_Error_t SpeakLog(const char *const log);
         CaveTalk_Error_t SpeakConfigServoWheels(const Servo &servo_wheel_0, const Servo &servo_wheel_1, const Servo &servo_wheel_2, const Servo &servo_wheel_3);

--- a/lib/c++/src/cave_talk.cc
+++ b/lib/c++/src/cave_talk.cc
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <functional>
 
+#include "arm.pb.h"
 #include "camera_movement.pb.h"
 #include "cave_talk_link.h"
 #include "cave_talk_types.h"
@@ -12,7 +13,6 @@
 #include "ids.pb.h"
 #include "lights.pb.h"
 #include "log.pb.h"
-#include "mode.pb.h"
 #include "movement.pb.h"
 #include "odometry.pb.h"
 #include "ooga_booga.pb.h"
@@ -58,8 +58,8 @@ CaveTalk_Error_t Listener::Listen(void)
         case ID_LIGHTS:
             error = HandleLights(length);
             break;
-        case ID_MODE:
-            error = HandleMode(length);
+        case ID_ARM:
+            error = HandleArm(length);
             break;
         case ID_ODOMETRY:
             error = HandleOdometry(length);
@@ -158,19 +158,18 @@ CaveTalk_Error_t Listener::HandleLights(CaveTalk_Length_t length) const
     return CAVE_TALK_ERROR_NONE;
 }
 
-CaveTalk_Error_t Listener::HandleMode(CaveTalk_Length_t length) const
+CaveTalk_Error_t Listener::HandleArm(CaveTalk_Length_t length) const
 {
+    Arm arm_message;
 
-    Mode mode_message;
-
-    if (!mode_message.ParseFromArray(buffer_.data(), length))
+    if (!arm_message.ParseFromArray(buffer_.data(), length))
     {
         return CAVE_TALK_ERROR_PARSE;
     }
 
-    const bool manual = mode_message.manual();
+    const bool arm = arm_message.arm();
 
-    listener_callbacks_->HearMode(manual);
+    listener_callbacks_->HearArm(arm);
 
     return CAVE_TALK_ERROR_NONE;
 }
@@ -339,15 +338,15 @@ CaveTalk_Error_t Talker::SpeakLights(const bool headlights)
     return CaveTalk_Speak(&link_handle_, static_cast<CaveTalk_Id_t>(ID_LIGHTS), message_buffer_.data(), length);
 }
 
-CaveTalk_Error_t Talker::SpeakMode(const bool manual)
+CaveTalk_Error_t Talker::SpeakArm(const bool arm)
 {
-    Mode mode_message;
-    mode_message.set_manual(manual);
+    Arm arm_message;
+    arm_message.set_arm(arm);
 
-    std::size_t length = mode_message.ByteSizeLong();
-    mode_message.SerializeToArray(message_buffer_.data(), message_buffer_.max_size());
+    std::size_t length = arm_message.ByteSizeLong();
+    arm_message.SerializeToArray(message_buffer_.data(), message_buffer_.max_size());
 
-    return CaveTalk_Speak(&link_handle_, static_cast<CaveTalk_Id_t>(ID_MODE), message_buffer_.data(), length);
+    return CaveTalk_Speak(&link_handle_, static_cast<CaveTalk_Id_t>(ID_ARM), message_buffer_.data(), length);
 }
 
 CaveTalk_Error_t Talker::SpeakLog(const char *const log)

--- a/lib/c/inc/cave_talk.h
+++ b/lib/c/inc/cave_talk.h
@@ -19,7 +19,7 @@ typedef struct
     void (*hear_movement)(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate);
     void (*hear_camera_movement)(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt);
     void (*hear_lights)(const bool headlights);
-    void (*hear_mode)(const bool manual);
+    void (*hear_arm)(const bool arm);
     void (*hear_odometry)(const cave_talk_Imu *const IMU, const cave_talk_Encoder *const encoder_wheel_0, const cave_talk_Encoder *const encoder_wheel_1, const cave_talk_Encoder *const encoder_wheel_2, const cave_talk_Encoder *const encoder_wheel_3);
     void (*hear_log)(const char *const log);
     void (*hear_config_servo_wheels)(const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3);
@@ -42,7 +42,7 @@ static const CaveTalk_ListenCallbacks_t kCaveTalk_ListenCallbacksNull = {
     .hear_movement            = NULL,
     .hear_camera_movement     = NULL,
     .hear_lights              = NULL,
-    .hear_mode                = NULL,
+    .hear_arm                 = NULL,
     .hear_odometry            = NULL,
     .hear_log                 = NULL,
     .hear_config_servo_wheels = NULL,
@@ -68,7 +68,7 @@ CaveTalk_Error_t CaveTalk_SpeakOogaBooga(const CaveTalk_Handle_t *const handle, 
 CaveTalk_Error_t CaveTalk_SpeakMovement(const CaveTalk_Handle_t *const handle, const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate);
 CaveTalk_Error_t CaveTalk_SpeakCameraMovement(const CaveTalk_Handle_t *const handle, const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt);
 CaveTalk_Error_t CaveTalk_SpeakLights(const CaveTalk_Handle_t *const handle, const bool headlights);
-CaveTalk_Error_t CaveTalk_SpeakMode(const CaveTalk_Handle_t *const handle, const bool manual);
+CaveTalk_Error_t CaveTalk_SpeakArm(const CaveTalk_Handle_t *const handle, const bool arm);
 CaveTalk_Error_t CaveTalk_SpeakLog(const CaveTalk_Handle_t *const handle, char *log);
 CaveTalk_Error_t CaveTalk_SpeakOdometry(const CaveTalk_Handle_t *const handle, const cave_talk_Imu *const IMU, const cave_talk_Encoder *const encoder_wheel_0, const cave_talk_Encoder *const encoder_wheel_1, const cave_talk_Encoder *const encoder_wheel_2, const cave_talk_Encoder *const encoder_wheel_3);
 CaveTalk_Error_t CaveTalk_SpeakConfigServoWheels(const CaveTalk_Handle_t *const handle, const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3);

--- a/lib/c/inc/cave_talk.h
+++ b/lib/c/inc/cave_talk.h
@@ -25,7 +25,7 @@ typedef struct
     void (*hear_config_servo_wheels)(const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3);
     void (*hear_config_servo_cams)(const cave_talk_Servo *const servo_cam_pan, const cave_talk_Servo *const servo_cam_tilt);
     void (*hear_config_motors)(const cave_talk_Motor *const motor_wheel_0, const cave_talk_Motor *const motor_wheel_1, const cave_talk_Motor *const motor_wheel_2, const cave_talk_Motor *const motor_wheel_3);
-    void (*hear_config_encoders)(const cave_talk_ConfigEncoder *const encoder_wheel_0,  const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3);
+    void (*hear_config_encoders)(const cave_talk_ConfigEncoder *const encoder_wheel_0, const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3);
 
 } CaveTalk_ListenCallbacks_t;
 
@@ -74,7 +74,7 @@ CaveTalk_Error_t CaveTalk_SpeakOdometry(const CaveTalk_Handle_t *const handle, c
 CaveTalk_Error_t CaveTalk_SpeakConfigServoWheels(const CaveTalk_Handle_t *const handle, const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3);
 CaveTalk_Error_t CaveTalk_SpeakConfigServoCams(const CaveTalk_Handle_t *const handle, const cave_talk_Servo *const servo_cam_pan, const cave_talk_Servo *const servo_cam_tilt);
 CaveTalk_Error_t CaveTalk_SpeakConfigMotors(const CaveTalk_Handle_t *const handle, const cave_talk_Motor *const motor_wheel_0, const cave_talk_Motor *const motor_wheel_1, const cave_talk_Motor *const motor_wheel_2, const cave_talk_Motor *const motor_wheel_3);
-CaveTalk_Error_t CaveTalk_SpeakConfigEncoders(const CaveTalk_Handle_t *const handle, const cave_talk_ConfigEncoder *const encoder_wheel_0,  const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3);
+CaveTalk_Error_t CaveTalk_SpeakConfigEncoders(const CaveTalk_Handle_t *const handle, const cave_talk_ConfigEncoder *const encoder_wheel_0, const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3);
 
 #ifdef __cplusplus
 }

--- a/messages/arm.proto
+++ b/messages/arm.proto
@@ -2,6 +2,6 @@ syntax = "proto3";
 
 package cave_talk;
 
-message Mode {
-    bool manual = 1;
+message Arm {
+    bool arm = 1;
 }

--- a/messages/ids.proto
+++ b/messages/ids.proto
@@ -8,7 +8,7 @@ enum Id {
     ID_MOVEMENT = 2;
     ID_CAMERA_MOVEMENT = 3;
     ID_LIGHTS = 4;
-    ID_MODE = 5;
+    ID_ARM = 5;
     ID_ODOMETRY = 6;
     ID_LOG = 7;
     ID_CONFIG_SERVO_WHEELS = 8;

--- a/tests/c++/cave_talk_tests.cc
+++ b/tests/c++/cave_talk_tests.cc
@@ -61,7 +61,6 @@ void TestServoObject(const cave_talk::Servo &a, const cave_talk::Servo &b)
     ASSERT_EQ(a.min_duty_cycle_microseconds(), b.min_duty_cycle_microseconds());
     ASSERT_EQ(a.max_duty_cycle_microseconds(), b.max_duty_cycle_microseconds());
     ASSERT_EQ(a.center_duty_cycle_microseconds(), b.center_duty_cycle_microseconds());
-
 }
 
 void TestMotorObject(const cave_talk::Motor &a, const cave_talk::Motor &b)
@@ -76,64 +75,63 @@ void TestMotorObject(const cave_talk::Motor &a, const cave_talk::Motor &b)
 void TestConfigEncoderObject(const cave_talk::ConfigEncoder &a, const cave_talk::ConfigEncoder &b)
 {
     ASSERT_EQ(a.smoothing_factor(), b.smoothing_factor());
-    ASSERT_EQ(a.radians_per_pulse(), b. radians_per_pulse());
+    ASSERT_EQ(a.radians_per_pulse(), b.radians_per_pulse());
     ASSERT_EQ(a.pulses_per_period(), b.pulses_per_period());
     ASSERT_EQ(a.mode(), b.mode());
 }
 
 class MockListenerCallbacks : public cave_talk::ListenerCallbacks
 {
-    public:
-        MOCK_METHOD(void, HearOogaBooga, (const cave_talk::Say), (override));
-        MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
-        MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
-        MOCK_METHOD(void, HearLights, (const bool), (override));
-        MOCK_METHOD(void, HearMode, (const bool), (override));
-        MOCK_METHOD(void, HearLog, (const char *const), (override));
+public:
+    MOCK_METHOD(void, HearOogaBooga, (const cave_talk::Say), (override));
+    MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
+    MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
+    MOCK_METHOD(void, HearLights, (const bool), (override));
+    MOCK_METHOD(void, HearArm, (const bool), (override));
+    MOCK_METHOD(void, HearLog, (const char *const), (override));
 
-        void HearOdometry(const cave_talk::Imu &IMU, const cave_talk::Encoder &encoder_wheel_0, const cave_talk::Encoder &encoder_wheel_1, const cave_talk::Encoder &encoder_wheel_2, const cave_talk::Encoder &encoder_wheel_3) override
-        {
-            TestIMUObject(imu_odometry_saved, IMU);
-            TestEncoderObject(encoder_odometry_saved_0, encoder_wheel_0);
-            TestEncoderObject(encoder_odometry_saved_1, encoder_wheel_1);
-            TestEncoderObject(encoder_odometry_saved_2, encoder_wheel_2);
-            TestEncoderObject(encoder_odometry_saved_3, encoder_wheel_3);
-        }
+    void HearOdometry(const cave_talk::Imu &IMU, const cave_talk::Encoder &encoder_wheel_0, const cave_talk::Encoder &encoder_wheel_1, const cave_talk::Encoder &encoder_wheel_2, const cave_talk::Encoder &encoder_wheel_3) override
+    {
+        TestIMUObject(imu_odometry_saved, IMU);
+        TestEncoderObject(encoder_odometry_saved_0, encoder_wheel_0);
+        TestEncoderObject(encoder_odometry_saved_1, encoder_wheel_1);
+        TestEncoderObject(encoder_odometry_saved_2, encoder_wheel_2);
+        TestEncoderObject(encoder_odometry_saved_3, encoder_wheel_3);
+    }
 
-        void HearConfigServoWheels(const cave_talk::Servo &servo_wheel_0, const cave_talk::Servo &servo_wheel_1, const cave_talk::Servo &servo_wheel_2, const cave_talk::Servo &servo_wheel_3) override
-        {
-            TestServoObject(servo_configservowheels_saved_0, servo_wheel_0);
-            TestServoObject(servo_configservowheels_saved_1, servo_wheel_1);
-            TestServoObject(servo_configservowheels_saved_2, servo_wheel_2);
-            TestServoObject(servo_configservowheels_saved_3, servo_wheel_3);
-        }
+    void HearConfigServoWheels(const cave_talk::Servo &servo_wheel_0, const cave_talk::Servo &servo_wheel_1, const cave_talk::Servo &servo_wheel_2, const cave_talk::Servo &servo_wheel_3) override
+    {
+        TestServoObject(servo_configservowheels_saved_0, servo_wheel_0);
+        TestServoObject(servo_configservowheels_saved_1, servo_wheel_1);
+        TestServoObject(servo_configservowheels_saved_2, servo_wheel_2);
+        TestServoObject(servo_configservowheels_saved_3, servo_wheel_3);
+    }
 
-        void HearConfigServoCams(const cave_talk::Servo &servo_cam_pan, const cave_talk::Servo &servo_cam_tilt)
-        {
-            TestServoObject(servo_configservocams_saved_pan, servo_cam_pan);
-            TestServoObject(servo_configservocams_saved_tilt, servo_cam_tilt);
-        }
-        
-        void HearConfigMotor(const cave_talk::Motor &motor_wheel_0, const cave_talk::Motor &motor_wheel_1, const cave_talk::Motor &motor_wheel_2, const cave_talk::Motor &motor_wheel_3)
-        {
-            TestMotorObject(motor_configmotor_saved_0, motor_wheel_0);
-            TestMotorObject(motor_configmotor_saved_1, motor_wheel_1);
-            TestMotorObject(motor_configmotor_saved_2, motor_wheel_2);
-            TestMotorObject(motor_configmotor_saved_3, motor_wheel_3);
-        }
+    void HearConfigServoCams(const cave_talk::Servo &servo_cam_pan, const cave_talk::Servo &servo_cam_tilt)
+    {
+        TestServoObject(servo_configservocams_saved_pan, servo_cam_pan);
+        TestServoObject(servo_configservocams_saved_tilt, servo_cam_tilt);
+    }
 
-        void HearConfigEncoder(const cave_talk::ConfigEncoder &encoder_wheel_0, const cave_talk::ConfigEncoder &encoder_wheel_1, const cave_talk::ConfigEncoder &encoder_wheel_2, const cave_talk::ConfigEncoder &encoder_wheel_3)
-        {
-            TestConfigEncoderObject(configencoder_configencoder_saved_0, encoder_wheel_0);
-            TestConfigEncoderObject(configencoder_configencoder_saved_1, encoder_wheel_1);
-            TestConfigEncoderObject(configencoder_configencoder_saved_2, encoder_wheel_2);
-            TestConfigEncoderObject(configencoder_configencoder_saved_3, encoder_wheel_3);
-        }
+    void HearConfigMotor(const cave_talk::Motor &motor_wheel_0, const cave_talk::Motor &motor_wheel_1, const cave_talk::Motor &motor_wheel_2, const cave_talk::Motor &motor_wheel_3)
+    {
+        TestMotorObject(motor_configmotor_saved_0, motor_wheel_0);
+        TestMotorObject(motor_configmotor_saved_1, motor_wheel_1);
+        TestMotorObject(motor_configmotor_saved_2, motor_wheel_2);
+        TestMotorObject(motor_configmotor_saved_3, motor_wheel_3);
+    }
+
+    void HearConfigEncoder(const cave_talk::ConfigEncoder &encoder_wheel_0, const cave_talk::ConfigEncoder &encoder_wheel_1, const cave_talk::ConfigEncoder &encoder_wheel_2, const cave_talk::ConfigEncoder &encoder_wheel_3)
+    {
+        TestConfigEncoderObject(configencoder_configencoder_saved_0, encoder_wheel_0);
+        TestConfigEncoderObject(configencoder_configencoder_saved_1, encoder_wheel_1);
+        TestConfigEncoderObject(configencoder_configencoder_saved_2, encoder_wheel_2);
+        TestConfigEncoderObject(configencoder_configencoder_saved_3, encoder_wheel_3);
+    }
 };
 
-
 CaveTalk_Error_t Send(const void *const data, const size_t size)
-{    
+{
     CaveTalk_Error_t error = CAVE_TALK_ERROR_NONE;
 
     if (size > ring_buffer.Capacity() - ring_buffer.Size())
@@ -154,7 +152,6 @@ CaveTalk_Error_t Receive(void *const data, const size_t size, size_t *const byte
 
     return CAVE_TALK_ERROR_NONE;
 }
-
 
 TEST(CaveTalkCppTests, SpeakListenOogaBooga)
 {
@@ -250,7 +247,7 @@ TEST(CaveTalkCppTests, SpeakListenLights)
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverEars.Listen());
 }
 
-TEST(CaveTalkCppTests, SpeakListenMode)
+TEST(CaveTalkCppTests, SpeakListenArm)
 {
     std::shared_ptr<MockListenerCallbacks> mock_listen_callbacks = std::make_shared<MockListenerCallbacks>();
     cave_talk::Talker roverMouth(Send);
@@ -258,14 +255,14 @@ TEST(CaveTalkCppTests, SpeakListenMode)
 
     ring_buffer.Clear();
 
-    ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverMouth.SpeakMode(true));
-    EXPECT_CALL(*mock_listen_callbacks.get(), HearMode(true)).Times(1);
+    ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverMouth.SpeakArm(true));
+    EXPECT_CALL(*mock_listen_callbacks.get(), HearArm(true)).Times(1);
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverEars.Listen());
 
     ring_buffer.Clear();
 
-    ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverMouth.SpeakMode(false));
-    EXPECT_CALL(*mock_listen_callbacks.get(), HearMode(false)).Times(1);
+    ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverMouth.SpeakArm(false));
+    EXPECT_CALL(*mock_listen_callbacks.get(), HearArm(false)).Times(1);
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverEars.Listen());
 }
 
@@ -281,7 +278,7 @@ TEST(CaveTalkCppTests, SpeakListenOdometry)
     accel.set_x_meters_per_second_squared(.0043);
     accel.set_y_meters_per_second_squared(.142);
     accel.set_z_meters_per_second_squared(5.2983);
-    
+
     cave_talk::Gyroscope gyro;
     gyro.set_pitch_radians_per_second(2.813);
     gyro.set_roll_radians_per_second(7.31342453);
@@ -291,13 +288,12 @@ TEST(CaveTalkCppTests, SpeakListenOdometry)
     IMU.mutable_accel()->CopyFrom(accel);
     IMU.mutable_gyro()->CopyFrom(gyro);
 
-
     cave_talk::Encoder encoder_0;
     encoder_0.set_rate_radians_per_second(3.141592652);
     encoder_0.set_total_pulses(100000);
 
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, roverMouth.SpeakOdometry(IMU, encoder_0, encoder_0, encoder_0, encoder_0));
-    
+
     imu_odometry_saved = IMU;
     encoder_odometry_saved_0 = encoder_0;
     encoder_odometry_saved_1 = encoder_0;

--- a/tests/c/cave_talk_tests.cc
+++ b/tests/c/cave_talk_tests.cc
@@ -12,12 +12,11 @@
 #include "cave_talk_types.h"
 #include "ring_buffer.h"
 
-
 static const std::size_t kMaxMessageLength = 255U;
 static RingBuffer<uint8_t, kMaxMessageLength> ring_buffer;
 
 CaveTalk_Error_t Send(const void *const data, const size_t size)
-{    
+{
     CaveTalk_Error_t error = CAVE_TALK_ERROR_NONE;
 
     if (size > ring_buffer.Capacity() - ring_buffer.Size())
@@ -90,7 +89,6 @@ void TestServoObject(const cave_talk_Servo &a, const cave_talk_Servo &b)
     ASSERT_EQ(a.min_duty_cycle_microseconds, b.min_duty_cycle_microseconds);
     ASSERT_EQ(a.max_duty_cycle_microseconds, b.max_duty_cycle_microseconds);
     ASSERT_EQ(a.center_duty_cycle_microseconds, b.center_duty_cycle_microseconds);
-
 }
 
 void TestMotorObject(const cave_talk_Motor &a, const cave_talk_Motor &b)
@@ -105,45 +103,44 @@ void TestMotorObject(const cave_talk_Motor &a, const cave_talk_Motor &b)
 void TestConfigEncoderObject(const cave_talk_ConfigEncoder &a, const cave_talk_ConfigEncoder &b)
 {
     ASSERT_EQ(a.smoothing_factor, b.smoothing_factor);
-    ASSERT_EQ(a.radians_per_pulse, b. radians_per_pulse);
+    ASSERT_EQ(a.radians_per_pulse, b.radians_per_pulse);
     ASSERT_EQ(a.pulses_per_period, b.pulses_per_period);
     ASSERT_EQ(a.mode, b.mode);
 }
 
 class ListenCallbacksInterface
 {
-    public:
-        virtual ~ListenCallbacksInterface()                                                                                   = 0;
-        virtual void HearOogaBooga(const cave_talk_Say ooga_booga)                                                               = 0;
-        virtual void HearMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate) = 0;
-        virtual void HearCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt)                     = 0;
-        virtual void HearLights(const bool headlights)                                                                 = 0;
-        virtual void HearMode(const bool manual)  = 0;
-        virtual void HearOdometry(const cave_talk_Imu *const imu, const cave_talk_Encoder *const encoder_wheel_0, const cave_talk_Encoder *const encoder_wheel_1, const cave_talk_Encoder *const encoder_wheel_2, const cave_talk_Encoder *const encoder_wheel_3) = 0;
-        virtual void HearLog(const char *const log) = 0;
-        virtual void HearConfigServoWheels(const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3) = 0;
-        virtual void HearConfigServoCams(const cave_talk_Servo *const servo_cam_pan, const cave_talk_Servo *const servo_cam_tilt) = 0;
-        virtual void HearConfigMotor(const cave_talk_Motor *const motor_wheel_0, const cave_talk_Motor *const motor_wheel_1, const cave_talk_Motor *const motor_wheel_2, const cave_talk_Motor *const motor_wheel_3) = 0;
-        virtual void HearConfigEncoder(const cave_talk_ConfigEncoder *const encoder_wheel_0, const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3) = 0;
+public:
+    virtual ~ListenCallbacksInterface() = 0;
+    virtual void HearOogaBooga(const cave_talk_Say ooga_booga) = 0;
+    virtual void HearMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate) = 0;
+    virtual void HearCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt) = 0;
+    virtual void HearLights(const bool headlights) = 0;
+    virtual void HearArm(const bool arm) = 0;
+    virtual void HearOdometry(const cave_talk_Imu *const imu, const cave_talk_Encoder *const encoder_wheel_0, const cave_talk_Encoder *const encoder_wheel_1, const cave_talk_Encoder *const encoder_wheel_2, const cave_talk_Encoder *const encoder_wheel_3) = 0;
+    virtual void HearLog(const char *const log) = 0;
+    virtual void HearConfigServoWheels(const cave_talk_Servo *const servo_wheel_0, const cave_talk_Servo *const servo_wheel_1, const cave_talk_Servo *const servo_wheel_2, const cave_talk_Servo *const servo_wheel_3) = 0;
+    virtual void HearConfigServoCams(const cave_talk_Servo *const servo_cam_pan, const cave_talk_Servo *const servo_cam_tilt) = 0;
+    virtual void HearConfigMotor(const cave_talk_Motor *const motor_wheel_0, const cave_talk_Motor *const motor_wheel_1, const cave_talk_Motor *const motor_wheel_2, const cave_talk_Motor *const motor_wheel_3) = 0;
+    virtual void HearConfigEncoder(const cave_talk_ConfigEncoder *const encoder_wheel_0, const cave_talk_ConfigEncoder *const encoder_wheel_1, const cave_talk_ConfigEncoder *const encoder_wheel_2, const cave_talk_ConfigEncoder *const encoder_wheel_3) = 0;
 };
 
 ListenCallbacksInterface::~ListenCallbacksInterface() = default;
 
 class MockListenCallbacks : public ListenCallbacksInterface
 {
-    public:
-        MOCK_METHOD(void, HearOogaBooga, (const cave_talk_Say), (override));
-        MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
-        MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
-        MOCK_METHOD(void, HearLights, (const bool), (override));
-        MOCK_METHOD(void, HearMode, (const bool), (override));
-        MOCK_METHOD(void, HearOdometry, ((const cave_talk_Imu *const imu), (const cave_talk_Encoder *const encoder_wheel_0), (const cave_talk_Encoder *const encoder_wheel_1), (const cave_talk_Encoder *const encoder_wheel_2), (const cave_talk_Encoder *const encoder_wheel_3)), (override));
-        MOCK_METHOD(void, HearLog, (const char *const), (override));
-        MOCK_METHOD(void, HearConfigServoWheels, ((const cave_talk_Servo *const servo_wheel_0), (const cave_talk_Servo *const servo_wheel_1), (const cave_talk_Servo *const servo_wheel_2), (const cave_talk_Servo *const servo_wheel_3)), (override));
-        MOCK_METHOD(void, HearConfigServoCams, ((const cave_talk_Servo *const servo_cam_pan), (const cave_talk_Servo *const servo_cam_tilt)), (override));
-        MOCK_METHOD(void, HearConfigMotor, ((const cave_talk_Motor *const motor_wheel_0), (const cave_talk_Motor *const motor_wheel_1), (const cave_talk_Motor *const motor_wheel_2), (const cave_talk_Motor *const motor_wheel_3)), (override));
-        MOCK_METHOD(void, HearConfigEncoder, ((const cave_talk_ConfigEncoder *const encoder_wheel_0), (const cave_talk_ConfigEncoder *const encoder_wheel_1), (const cave_talk_ConfigEncoder *const encoder_wheel_2), (const cave_talk_ConfigEncoder *const encoder_wheel_3)), (override));
-
+public:
+    MOCK_METHOD(void, HearOogaBooga, (const cave_talk_Say), (override));
+    MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
+    MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
+    MOCK_METHOD(void, HearLights, (const bool), (override));
+    MOCK_METHOD(void, HearArm, (const bool), (override));
+    MOCK_METHOD(void, HearOdometry, ((const cave_talk_Imu *const imu), (const cave_talk_Encoder *const encoder_wheel_0), (const cave_talk_Encoder *const encoder_wheel_1), (const cave_talk_Encoder *const encoder_wheel_2), (const cave_talk_Encoder *const encoder_wheel_3)), (override));
+    MOCK_METHOD(void, HearLog, (const char *const), (override));
+    MOCK_METHOD(void, HearConfigServoWheels, ((const cave_talk_Servo *const servo_wheel_0), (const cave_talk_Servo *const servo_wheel_1), (const cave_talk_Servo *const servo_wheel_2), (const cave_talk_Servo *const servo_wheel_3)), (override));
+    MOCK_METHOD(void, HearConfigServoCams, ((const cave_talk_Servo *const servo_cam_pan), (const cave_talk_Servo *const servo_cam_tilt)), (override));
+    MOCK_METHOD(void, HearConfigMotor, ((const cave_talk_Motor *const motor_wheel_0), (const cave_talk_Motor *const motor_wheel_1), (const cave_talk_Motor *const motor_wheel_2), (const cave_talk_Motor *const motor_wheel_3)), (override));
+    MOCK_METHOD(void, HearConfigEncoder, ((const cave_talk_ConfigEncoder *const encoder_wheel_0), (const cave_talk_ConfigEncoder *const encoder_wheel_1), (const cave_talk_ConfigEncoder *const encoder_wheel_2), (const cave_talk_ConfigEncoder *const encoder_wheel_3)), (override));
 };
 
 std::shared_ptr<MockListenCallbacks> mock_calls = std::make_shared<MockListenCallbacks>();
@@ -162,14 +159,14 @@ static void HearCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radia
     return (mock_calls.get())->HearCameraMovement(pan, tilt);
 }
 
-static void HearLights(const bool headlights) 
+static void HearLights(const bool headlights)
 {
     return (mock_calls.get())->HearLights(headlights);
 }
 
-static void HearMode(const bool manual)
+static void HearArm(const bool arm)
 {
-    return (mock_calls.get())->HearMode(manual);
+    return (mock_calls.get())->HearArm(arm);
 }
 
 static void HearLog(const char *const log)
@@ -217,11 +214,11 @@ void HearConfigEncoder(const cave_talk_ConfigEncoder *const encoder_wheel_0, con
 }
 
 const CaveTalk_ListenCallbacks_t kCaveTalk_ListenCallbacksInterface = {
-    .hear_ooga_booga      = HearOogaBooga,
-    .hear_movement        = HearMovement,
+    .hear_ooga_booga = HearOogaBooga,
+    .hear_movement = HearMovement,
     .hear_camera_movement = HearCameraMovement,
-    .hear_lights          = HearLights,
-    .hear_mode            = HearMode,
+    .hear_lights = HearLights,
+    .hear_arm = HearArm,
     .hear_odometry = HearOdometry,
     .hear_log = HearLog,
     .hear_config_servo_wheels = HearConfigServoWheels,
@@ -232,12 +229,12 @@ const CaveTalk_ListenCallbacks_t kCaveTalk_ListenCallbacksInterface = {
 
 class MockListenerCallbacks : public ListenCallbacksInterface
 {
-    public:
-        MOCK_METHOD(void, HearOogaBooga, (const cave_talk_Say), (override));
-        MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
-        MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
-        MOCK_METHOD(void, HearLights, (const bool), (override));
-        MOCK_METHOD(void, HearMode, (const bool), (override));
+public:
+    MOCK_METHOD(void, HearOogaBooga, (const cave_talk_Say), (override));
+    MOCK_METHOD(void, HearMovement, ((const CaveTalk_MetersPerSecond_t), (const CaveTalk_RadiansPerSecond_t)), (override));
+    MOCK_METHOD(void, HearCameraMovement, ((const CaveTalk_Radian_t), (const CaveTalk_Radian_t)), (override));
+    MOCK_METHOD(void, HearLights, (const bool), (override));
+    MOCK_METHOD(void, HearArm, (const bool), (override));
 };
 
 static CaveTalk_Handle_t CaveTalk_Handle = {
@@ -315,18 +312,18 @@ TEST(CaveTalkCTests, SpeakListenLights)
     mock_calls.reset();
 }
 
-TEST(CaveTalkCTests, SpeakListenMode)
+TEST(CaveTalkCTests, SpeakListenArm)
 {
     ring_buffer.Clear();
 
-    ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakMode(&CaveTalk_Handle, true));
-    EXPECT_CALL(*mock_calls.get(), HearMode(true)).Times(1);
+    ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakArm(&CaveTalk_Handle, true));
+    EXPECT_CALL(*mock_calls.get(), HearArm(true)).Times(1);
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_Hear(&CaveTalk_Handle));
 
     ring_buffer.Clear();
 
-    ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakMode(&CaveTalk_Handle, false));
-    EXPECT_CALL(*mock_calls.get(), HearMode(false)).Times(1);
+    ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakArm(&CaveTalk_Handle, false));
+    EXPECT_CALL(*mock_calls.get(), HearArm(false)).Times(1);
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_Hear(&CaveTalk_Handle));
 
     mock_calls.reset();
@@ -341,7 +338,7 @@ TEST(CaveTalkCTests, SpeakListenOdometry)
     imu.accel.x_meters_per_second_squared = .00004;
     imu.accel.y_meters_per_second_squared = .03004;
     imu.accel.z_meters_per_second_squared = 152352.2038492;
-    
+
     imu.has_gyro = true;
     imu.gyro.pitch_radians_per_second = 17029348.57032894;
     imu.gyro.roll_radians_per_second = 123.00000000000001;
@@ -350,7 +347,6 @@ TEST(CaveTalkCTests, SpeakListenOdometry)
     cave_talk_Encoder encoder_test = cave_talk_Encoder();
     encoder_test.rate_radians_per_second = 6.1412341231;
     encoder_test.total_pulses = 999921;
-
 
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakOdometry(&CaveTalk_Handle, &imu, &encoder_test, &encoder_test, &encoder_test, &encoder_test));
     imu_odometry_saved = imu;
@@ -389,7 +385,6 @@ TEST(CaveTalkCTests, SpeakListenConfigServoWheels)
     (servo_test_zero).min_duty_cycle_microseconds = (540);
     (servo_test_zero).max_duty_cycle_microseconds = (2560);
     (servo_test_zero).center_duty_cycle_microseconds = (1576);
-
 
     ASSERT_EQ(CAVE_TALK_ERROR_NONE, CaveTalk_SpeakConfigServoWheels(&CaveTalk_Handle, &servo_test_zero, &servo_test_zero, &servo_test_zero, &servo_test_zero));
     servo_configservowheels_saved_0 = servo_test_zero;


### PR DESCRIPTION
Replace Mode message with Arm message.  Mode message is unnecessary because the rover uses the same interface to drive in manual mode and autonomous mode.  Arm message allows driving and steering to be enabled and disabled.